### PR TITLE
January 2020 demo fixes

### DIFF
--- a/src/Foundation/CoveoIndexing/website/ComputedFields/ListPriceComputedField.cs
+++ b/src/Foundation/CoveoIndexing/website/ComputedFields/ListPriceComputedField.cs
@@ -85,7 +85,7 @@ namespace Sitecore.HabitatHome.Foundation.CoveoIndexing.ComputedFields
             var putData = "{ \"itemIds\": [\"" + catalogName + "|" + productSku + "|\"] }";
             var data = Encoding.ASCII.GetBytes(putData);
 
-            var request = WebRequest.CreateHttp("https://localhost:5000/api/GetBulkPrices()");
+            var request = WebRequest.CreateHttp("https://habitathome.coveodemo.com:5000/api/GetBulkPrices()");
             request.ContentType = "application/json";
             request.Headers.Add("ShopName", "CommerceEngineDefaultStorefront");
             request.Headers.Add("ShopperId", "ShopperId");
@@ -106,7 +106,7 @@ namespace Sitecore.HabitatHome.Foundation.CoveoIndexing.ComputedFields
             var responseString = new StreamReader(response.GetResponseStream()).ReadToEnd();
             // Example 8.2.1:
             //{
-            //  "@odata.context":"https://localhost:5000/Api/$metadata#Collection(Sitecore.Commerce.Plugin.Catalog.SellableItemPricing)","value":[
+            //  "@odata.context":"https://habitathome.coveodemo.com:5000/Api/$metadata#Collection(Sitecore.Commerce.Plugin.Catalog.SellableItemPricing)","value":[
             //    {
             //      "Name":"Mens Axelion Running Shoe","Policies":[
 
@@ -131,7 +131,7 @@ namespace Sitecore.HabitatHome.Foundation.CoveoIndexing.ComputedFields
 
             // Example 9.0.2:
             //{
-            //  "@odata.context":"https://localhost:5000/Api/$metadata#Collection(Sitecore.Commerce.Plugin.Catalog.SellableItemPricing)","value":[
+            //  "@odata.context":"https://habitathome.coveodemo.com:5000/Api/$metadata#Collection(Sitecore.Commerce.Plugin.Catalog.SellableItemPricing)","value":[
             //    {
             //      "Name":"Habitat Spectra 65\u201d 4K LED Ultra HD Television","Policies":[
 
@@ -165,11 +165,11 @@ namespace Sitecore.HabitatHome.Foundation.CoveoIndexing.ComputedFields
         private string GetToken()
         {
             string token = null;
-            string password = "b"; // "FLoWNGLeNeAT";
+            string password = "b";
             var postData = "password=" + password + "&grant_type=password&username=sitecore\\admin&client_id=postman-api&scope=openid EngineAPI postman_api";
             var data = Encoding.ASCII.GetBytes(postData);
 
-            var request = WebRequest.CreateHttp("https://localhost:5050/connect/token");
+            var request = WebRequest.CreateHttp("https://habitathome.coveodemo.com:5050/connect/token");
             request.ContentType = "application/x-www-form-urlencoded";
             request.Accept = "application/json";
             request.Method = "POST";

--- a/src/Project/HabitatHome/serialization/Users/sitecore/demoadmin.yml
+++ b/src/Project/HabitatHome/serialization/Users/sitecore/demoadmin.yml
@@ -3,7 +3,7 @@ Username: |
   sitecore\demoadmin
 Email: admin@demo.com
 Comment: Demo Administrator
-Created: "2018-07-24T17:41:25.0000000Z"
+Created: "2018-09-20T19:23:03.0000000Z"
 IsApproved: True
 Properties:
 - Key: FullName
@@ -33,6 +33,8 @@ Roles:
     sitecore\Analytics Testing
   MemberOf: |
     sitecore\Author
+  MemberOf: |
+    sitecore\Commerce Administrator
   MemberOf: |
     sitecore\Commerce Business User
   MemberOf: |


### PR DESCRIPTION
After habitathome.coveodemo.com SSL certificates expired in 2019, the demo was not working anymore. While fixing it, I had to do some changes in the code:

* Changed commerce engine hostname in URLs in a computed field.
* Assigned the sitecore\Commerce Administrator role to all users on the instance so they have access to commerce business tools.

Checks:

* [ x ] Have you followed the guidelines in our Contributing document?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ No ] Have you written new tests for your core changes, as applicable?
* [ Manual sanity checkup only ] Have you successfully ran tests with your changes locally?
